### PR TITLE
Fix uri.var.maxRecords parameter not working issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.carbon.esb.connector</groupId>
     <artifactId>org.wso2.carbon.esb.connector.salesforce-bulkapi-v2</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <packaging>jar</packaging>
     <name>WSO2 Carbon - Connector For salesforce-bulkapi-v2</name>
     <url>http://wso2.org</url>

--- a/src/main/java/org/wso2/carbon/esb/connector/utils/SalesforceUtils.java
+++ b/src/main/java/org/wso2/carbon/esb/connector/utils/SalesforceUtils.java
@@ -154,19 +154,26 @@ public class SalesforceUtils {
 
     public static String getGetQueryJobResultUrl(SalesforceConfig salesforceConfig, String queryJobId,
                                                  Integer maxRecords, String locator) {
-        String paramString = "";
-        if (maxRecords != null) {
-            paramString += SalesforceConstants.LOCATOR + "=" + locator;
-        }
+        StringBuilder paramString = new StringBuilder();
+        // Append locator if it is not null and not empty
         if (StringUtils.isNotEmpty(locator)) {
-            if (StringUtils.isNotEmpty(paramString)) {
-                paramString += "&";
+            paramString.append(SalesforceConstants.LOCATOR).append("=").append(locator);
+        }
+
+        // Append maxRecords if it is not null
+        if (maxRecords != null) {
+            if (paramString.length() > 0) {
+                paramString.append("&");
             }
-            paramString += SalesforceConstants.MAX_RECORDS + "=" + maxRecords;
+            paramString.append(SalesforceConstants.MAX_RECORDS).append("=").append(maxRecords);
         }
-        if (StringUtils.isNotEmpty(paramString)) {
-            paramString = "?" + paramString;
+
+        // Prepend ? if there are any parameters
+        if (paramString.length() > 0) {
+            paramString.insert(0, "?");
         }
+
+        // Construct the final URL
         return salesforceConfig.getInstanceUrl() + SalesforceConstants.SF_API_JOBS_QUERY_RELATIVE_PATH + queryJobId
                 + SalesforceConstants.SF_API_JOBS_QUERY_RESULTS_RELATIVE_PATH
                 + paramString;


### PR DESCRIPTION
## Purpose
Due to a logical error, `uri.var.maxRecords` parameter was not working before. This PR fixes that bug.

Fixes https://github.com/wso2/micro-integrator/issues/3360
